### PR TITLE
Removed Hardcoded values for world height with min and max world heig…

### DIFF
--- a/src/main/java/com/arcaniax/gobrush/GoBrushPlugin.java
+++ b/src/main/java/com/arcaniax/gobrush/GoBrushPlugin.java
@@ -109,10 +109,8 @@ public class GoBrushPlugin extends JavaPlugin {
 
         try {
             Class.forName("org.bukkit.generator.WorldInfo");
-            getLogger().info("WorldInfo class found! Setting to use new world limits.");
             BlockUtils.setNewerWorldVersion(true);
         } catch (ClassNotFoundException ignored) {
-            getLogger().info("WorldInfo class not found! Setting to original world limits.");
         }
     }
 

--- a/src/main/java/com/arcaniax/gobrush/GoBrushPlugin.java
+++ b/src/main/java/com/arcaniax/gobrush/GoBrushPlugin.java
@@ -31,6 +31,7 @@ import com.arcaniax.gobrush.listener.InventoryClickListener;
 import com.arcaniax.gobrush.listener.PlayerInteractListener;
 import com.arcaniax.gobrush.listener.PlayerJoinListener;
 import com.arcaniax.gobrush.listener.PlayerQuitListener;
+import com.arcaniax.gobrush.util.BlockUtils;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import io.papermc.lib.PaperLib;
 import org.bstats.bukkit.Metrics;
@@ -105,6 +106,14 @@ public class GoBrushPlugin extends JavaPlugin {
                 return "201+";
             }
         }));
+
+        try {
+            Class.forName("org.bukkit.generator.WorldInfo");
+            getLogger().info("WorldInfo class found! Setting to use new world limits.");
+            BlockUtils.setNewerWorldVersion(true);
+        } catch (ClassNotFoundException ignored) {
+            getLogger().info("WorldInfo class not found! Setting to original world limits.");
+        }
     }
 
     private void registerListeners() {

--- a/src/main/java/com/arcaniax/gobrush/listener/PlayerInteractListener.java
+++ b/src/main/java/com/arcaniax/gobrush/listener/PlayerInteractListener.java
@@ -131,8 +131,8 @@ public class PlayerInteractListener implements Listener {
                                         int worldHeight = editsession.getHighestTerrainBlock(
                                                 loopLoc.getBlockX(),
                                                 loopLoc.getBlockZ(),
-                                                0,
-                                                255
+                                                loc.getWorld().getMinHeight(),
+                                                loc.getWorld().getMaxHeight()
                                         );
                                         if (editsession.getMask() == null || editsession
                                                 .getMask()

--- a/src/main/java/com/arcaniax/gobrush/listener/PlayerInteractListener.java
+++ b/src/main/java/com/arcaniax/gobrush/listener/PlayerInteractListener.java
@@ -173,7 +173,7 @@ public class PlayerInteractListener implements Listener {
                                                         if (editsession.getMask() == null || editsession.getMask().test(Vector3
                                                                 .at(l.getBlockX(), l.getBlockY() - y, l.getBlockZ())
                                                                 .toBlockPoint())) {
-                                                            if (!(l.getBlockY() - y < 0)) {
+                                                            if (!(l.getBlockY() - y < BlockUtils.getWorldMin(l))) {
                                                                 try {
                                                                     blocksToSet.put(Vector3.at(
                                                                             l.getBlockX(),

--- a/src/main/java/com/arcaniax/gobrush/listener/PlayerInteractListener.java
+++ b/src/main/java/com/arcaniax/gobrush/listener/PlayerInteractListener.java
@@ -28,6 +28,7 @@ package com.arcaniax.gobrush.listener;
 
 import com.arcaniax.gobrush.Session;
 import com.arcaniax.gobrush.object.BrushPlayer;
+import com.arcaniax.gobrush.util.BlockUtils;
 import com.arcaniax.gobrush.util.BrushPlayerUtil;
 import com.arcaniax.gobrush.util.GuiGenerator;
 import com.arcaniax.gobrush.util.NestedFor;
@@ -131,8 +132,8 @@ public class PlayerInteractListener implements Listener {
                                         int worldHeight = editsession.getHighestTerrainBlock(
                                                 loopLoc.getBlockX(),
                                                 loopLoc.getBlockZ(),
-                                                loc.getWorld().getMinHeight(),
-                                                loc.getWorld().getMaxHeight()
+                                                BlockUtils.getWorldMin(loc),
+                                                BlockUtils.getWorldMax(loc)
                                         );
                                         if (editsession.getMask() == null || editsession
                                                 .getMask()

--- a/src/main/java/com/arcaniax/gobrush/object/HeightMapExporter.java
+++ b/src/main/java/com/arcaniax/gobrush/object/HeightMapExporter.java
@@ -27,6 +27,7 @@
 package com.arcaniax.gobrush.object;
 
 import com.arcaniax.gobrush.GoBrushPlugin;
+import com.arcaniax.gobrush.util.BlockUtils;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.IncompleteRegionException;
 import com.sk89q.worldedit.WorldEdit;
@@ -96,7 +97,9 @@ public class HeightMapExporter {
             for (int z = 0; z < (maxZ - minZ); z++) {
                 BukkitPlayer bp = new BukkitPlayer(p);
                 EditSession editsession = WorldEdit.getInstance().getSessionManager().get(bp).createEditSession(bp);
-                int y = editsession.getHighestTerrainBlock(x + minX, z + minZ, 0, 255);
+                int y = editsession.getHighestTerrainBlock(x + minX, z + minZ,
+                        BlockUtils.getWorldMin(bp.getPlayer().getLocation()), BlockUtils.getWorldMax(bp.getPlayer().getLocation())
+                );
                 if (y > highest) {
                     highest = y;
                 }
@@ -115,7 +118,9 @@ public class HeightMapExporter {
             for (int z = 0; z < (maxZ - minZ); z++) {
                 BukkitPlayer bp = new BukkitPlayer(p);
                 EditSession editsession = WorldEdit.getInstance().getSessionManager().get(bp).createEditSession(bp);
-                int y = editsession.getHighestTerrainBlock(x + minX, z + minZ, 0, 255);
+                int y = editsession.getHighestTerrainBlock(x + minX, z + minZ,
+                        BlockUtils.getWorldMin(bp.getPlayer().getLocation()), BlockUtils.getWorldMax(bp.getPlayer().getLocation())
+                );
                 int i = (int) (((double) (y - lowest) / (double) height) * (double) 255);
                 int rgb = i; //red
                 rgb = (rgb << 8) + i;//green

--- a/src/main/java/com/arcaniax/gobrush/util/BlockUtils.java
+++ b/src/main/java/com/arcaniax/gobrush/util/BlockUtils.java
@@ -30,10 +30,32 @@ import org.bukkit.Location;
 
 public class BlockUtils {
 
+    private static boolean NEWER_WORLD_VERSION = false;
+
+    public static void setNewerWorldVersion(boolean newer) {
+        NEWER_WORLD_VERSION = newer;
+    }
+
     public static boolean isLoaded(Location l) {
         int x = l.getBlockX() >> 4;
         int z = l.getBlockZ() >> 4;
         return l.getWorld().isChunkLoaded(x, z);
+    }
+
+    public static int getWorldMin(Location loc) {
+        if (NEWER_WORLD_VERSION) {
+            return loc.getWorld().getMinHeight();
+        } else {
+            return 0;
+        }
+    }
+
+    public static int getWorldMax(Location loc) {
+        if (NEWER_WORLD_VERSION) {
+            return loc.getWorld().getMaxHeight();
+        } else {
+            return 255;
+        }
     }
 
 }

--- a/src/main/java/com/arcaniax/gobrush/util/BrushPlayerUtil.java
+++ b/src/main/java/com/arcaniax/gobrush/util/BrushPlayerUtil.java
@@ -55,10 +55,10 @@ public class BrushPlayerUtil {
             if (!BlockUtils.isLoaded(loc)) {
                 return null;
             }
-            if (loc.getBlockY() <= loc.getWorld().getMinHeight()) {
+            if (loc.getBlockY() <= BlockUtils.getWorldMin(loc)) {
                 break;
             }
-            if (loc.getBlockY() > loc.getWorld().getMaxHeight()) {
+            if (loc.getBlockY() > BlockUtils.getWorldMax(loc)) {
                 return null;
             }
             if (loc.distance(_loc) > 200) {
@@ -76,10 +76,10 @@ public class BrushPlayerUtil {
             if (!BlockUtils.isLoaded(loc)) {
                 return null;
             }
-            if (loc.getBlockY() <= loc.getWorld().getMinHeight()) {
+            if (loc.getBlockY() <= BlockUtils.getWorldMin(loc)) {
                 break;
             }
-            if (loc.getBlockY() > loc.getWorld().getMaxHeight()) {
+            if (loc.getBlockY() > BlockUtils.getWorldMax(loc)) {
                 return null;
             }
             if (loc.distance(player.getEyeLocation()) > 200) {

--- a/src/main/java/com/arcaniax/gobrush/util/BrushPlayerUtil.java
+++ b/src/main/java/com/arcaniax/gobrush/util/BrushPlayerUtil.java
@@ -55,10 +55,10 @@ public class BrushPlayerUtil {
             if (!BlockUtils.isLoaded(loc)) {
                 return null;
             }
-            if (loc.getBlockY() <= 0) {
+            if (loc.getBlockY() <= loc.getWorld().getMinHeight()) {
                 break;
             }
-            if (loc.getBlockY() > 255) {
+            if (loc.getBlockY() > loc.getWorld().getMaxHeight()) {
                 return null;
             }
             if (loc.distance(_loc) > 200) {
@@ -76,10 +76,10 @@ public class BrushPlayerUtil {
             if (!BlockUtils.isLoaded(loc)) {
                 return null;
             }
-            if (loc.getBlockY() <= 0) {
+            if (loc.getBlockY() <= loc.getWorld().getMinHeight()) {
                 break;
             }
-            if (loc.getBlockY() > 255) {
+            if (loc.getBlockY() > loc.getWorld().getMaxHeight()) {
                 return null;
             }
             if (loc.distance(player.getEyeLocation()) > 200) {


### PR DESCRIPTION
…ht methods.

## Overview
<!--  Please describe which issue this Pull Request targets

If there is no issue, please create one so we can look into it before approving your PR.
You can do so here: https://github.com/Arcaniax-Development/goBrush/issues
-->

<!-- Remove the brackets around the issue to connect your pull request with the issue it resolves -->
**Fixes #55**

## Description
<!-- Please describe what you have changed -->
Changed Hardcoded world height values to new world API provided methods that grab the current world's max and min height requirements. In my minimal testing on my test server, this does appear to be working properly in 1.18 now.
## Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
