### PR TITLE
Update getClosest in BrushPlayerUtil.java

### DIFF
--- a/src/main/java/com/arcaniax/gobrush/util/BrushPlayerUtil.java
+++ b/src/main/java/com/arcaniax/gobrush/util/BrushPlayerUtil.java
@@ -23,6 +23,8 @@ import com.arcaniax.gobrush.object.BrushPlayer;
 import com.sk89q.worldedit.EditSession;
 import com.sk89q.worldedit.math.Vector3;
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.util.Vector;
 
@@ -36,15 +38,28 @@ public class BrushPlayerUtil {
 
     public static Location getClosest(Player player, Location _loc, Location l, int brushSize, EditSession session) {
         Location loc = _loc.clone();
+        Location locPrev = loc.clone();
 
-        while (loc.getBlock().getType() == XMaterial.AIR.parseMaterial()
+        Block locBlock = loc.getBlock();
+        Material locMaterial = locBlock.getType();
+        Material air = XMaterial.AIR.parseMaterial();
+        Vector v = player.getEyeLocation().getDirection().multiply(0.5);
+
+        while (locMaterial == air
                 || (!(session.getMask() == null || session.getMask().test(Vector3
                 .at(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ())
                 .toBlockPoint())))
                 && (loc.distance(l.clone().add(0.5, 0.5, 0.5)) < ((double) brushSize / (double) 4))) {
-            Vector v = player.getEyeLocation().getDirection();
-            loc.add(v.multiply(0.5));
-            if (!BlockUtils.isLoaded(loc)) {
+            loc.add(v);
+            boolean newBlockPos =
+                    (loc.getBlockX() != locPrev.getBlockX() || loc.getBlockY() != locPrev.getBlockY() || loc.getBlockZ() != locPrev.getBlockZ());
+            if (newBlockPos) {
+                locBlock = loc.getBlock();
+                locMaterial = locBlock.getType();
+            }
+            locPrev = loc.clone();
+
+            if (newBlockPos && !BlockUtils.isLoaded(loc)) {
                 return null;
             }
             if (loc.getBlockY() <= BlockUtils.getWorldMin(loc)) {


### PR DESCRIPTION
(First time pull requester so hopefully this is right)

## Overview
When you use a brush and it looks for the block in sight & range, .getBlock().getType() was called every iteration. 
This change instead only calls this when loc has actually moved a full block. BlockUtils.isLoaded() also changed to only run when it's a new block.

Added "Material air" as a variable so we only need to run parseMaterial() once.

**Fixes #99**

## Description
getClosest() now keeps track of the last location checked and only updates locBlock & locMaterial when the Block position has changed replacing loc.getBlock().getMaterial().
This is also used to only run BlockUtils.isLoaded(loc) when the position has actually updated.

The change reduces the calls by about 50%.

Additionally added the "air" variable prior to the loop, so that parseMaterial() isn't called every iteration, the performance impact is fairly negligable though.

## Checklist
- [X] I included all information required in the sections above
- [X] I tested my changes and approved their functionality
- [X] I ensured my changes do not break other parts of the code
